### PR TITLE
fix: browse category filter & description length

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -18,6 +18,7 @@ data:
   categories_dir: "tags"
   platforms_dir: "platforms"
   licenses_file: "licenses.yml"
+  licenses_nonfree_file: "licenses-nonfree.yml"
 
 # =============================================================================
 # BUILD SETTINGS
@@ -57,7 +58,7 @@ ui:
   truncation:
     default_description_length: 150
     homepage_description_length: 70
-    browse_description_length: 250
+    browse_description_length: 90
     browse_description_full: false
     related_apps_description_length: 100
 

--- a/src/data_processor.py
+++ b/src/data_processor.py
@@ -77,7 +77,7 @@ class DataProcessor:
 
         # Load licenses data (both free and non-free)
         licenses_file = data_dir / data_config["licenses_file"]
-        licenses_nonfree_file = data_dir / "licenses-nonfree.yml"
+        licenses_nonfree_file = data_dir / data_config["licenses_nonfree_file"]
         licenses_data = self._load_licenses_data(licenses_file, licenses_nonfree_file)
 
         # Load markdown files

--- a/src/site_generator.py
+++ b/src/site_generator.py
@@ -201,17 +201,7 @@ class SiteGenerator:
             if cat_info["count"] > 0:
                 # Create slugified version of the category name for consistent URLs
                 category_name = cat_info["name"]
-                category_slug = (
-                    category_name.lower()
-                    .replace(" ", "-")
-                    .replace("&", "")
-                    .replace("(", "")
-                    .replace(")", "")
-                    .replace(",", "")
-                    .replace("/", "-")
-                    .replace("--", "-")
-                    .strip("-")
-                )
+                category_slug = self.template_helpers.slugify(category_name)
 
                 category_stats.append(
                     {

--- a/static/js/browse.js
+++ b/static/js/browse.js
@@ -700,7 +700,7 @@ class BrowsePage {
                     </div>
                 </div>
                 
-                <p class="text-sm text-gray-600 dark:text-gray-300 mb-3 line-clamp-2 flex-grow">
+                <p class="text-sm text-gray-600 dark:text-gray-300 mb-3 flex-grow">
                     ${this.truncateDescription(app.description)}
                 </p>
                 


### PR DESCRIPTION
- Fixed the category filter to use the correct slug when used via the homepage
- Fixed that configured truncate length is respected
- Reduced default browse description length to 90 characters
- Added non-free licenses to the config.yml