### PR TITLE
feat: add license URL functionality to app detail page

### DIFF
--- a/src/site_generator.py
+++ b/src/site_generator.py
@@ -77,6 +77,7 @@ class SiteGenerator:
                 "url_for": self.template_helpers.url_for,
                 "asset_url": self.template_helpers.asset_url,
                 "filter_navigation": self.template_helpers.filter_navigation,
+                "get_license_url": self.template_helpers.get_license_url,
             }
         )
 

--- a/src/template_helpers.py
+++ b/src/template_helpers.py
@@ -559,3 +559,19 @@ class TemplateHelpers:
             filtered_items.append(item)
 
         return filtered_items
+
+    def get_license_url(self, license_id: str) -> str:
+        """Get the URL for a license."""
+        if not license_id or not self.licenses_data:
+            return ""
+        
+        # Try exact match
+        if license_id in self.licenses_data:
+            return self.licenses_data[license_id].get("url", "")
+        
+        # Try case-insensitive match
+        for lic_id, lic_info in self.licenses_data.items():
+            if lic_id.lower() == license_id.lower():
+                return lic_info.get("url", "")
+        
+        return ""

--- a/static/css/tailwind.css
+++ b/static/css/tailwind.css
@@ -413,6 +413,9 @@
   .mb-12 {
     margin-bottom: calc(var(--spacing) * 12);
   }
+  .ml-0\.5 {
+    margin-left: calc(var(--spacing) * 0.5);
+  }
   .ml-1 {
     margin-left: calc(var(--spacing) * 1);
   }
@@ -461,6 +464,9 @@
   .h-2 {
     height: calc(var(--spacing) * 2);
   }
+  .h-2\.5 {
+    height: calc(var(--spacing) * 2.5);
+  }
   .h-3 {
     height: calc(var(--spacing) * 3);
   }
@@ -508,6 +514,9 @@
   }
   .w-0\.5 {
     width: calc(var(--spacing) * 0.5);
+  }
+  .w-2\.5 {
+    width: calc(var(--spacing) * 2.5);
   }
   .w-3 {
     width: calc(var(--spacing) * 3);
@@ -989,6 +998,9 @@
   }
   .text-right {
     text-align: right;
+  }
+  .align-super {
+    vertical-align: super;
   }
   .text-2xl {
     font-size: var(--text-2xl);

--- a/templates/pages/app_detail.html
+++ b/templates/pages/app_detail.html
@@ -185,6 +185,14 @@
                             {% else %}
                                 {{ format_license(license) }}
                             {% endif %}
+                            {% set license_url = get_license_url(license) %}
+                            {% if license_url %}
+                            <a href="{{ license_url }}"{{ get_link_target_attrs(license_url, false) | safe }} class="inline-block align-super ml-0.5 hover:text-primary-600 dark:hover:text-primary-400 transition-colors">
+                                <svg class="w-2.5 h-2.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"/>
+                                </svg>
+                            </a>
+                            {% endif %}
                             {%- if not loop.last %} / {% endif %}
                         {% endfor %}
                     {% else %}
@@ -192,6 +200,14 @@
                             <span class="text-orange-700 dark:text-orange-300">{{ format_license(app.license) }}</span>
                         {% else %}
                             {{ format_license(app.license) }}
+                        {% endif %}
+                        {% set license_url = get_license_url(app.license) %}
+                        {% if license_url %}
+                        <a href="{{ license_url }}"{{ get_link_target_attrs(license_url, false) | safe }} class="inline-block align-super ml-0.5 hover:text-primary-600 dark:hover:text-primary-400 transition-colors">
+                            <svg class="w-2.5 h-2.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"/>
+                            </svg>
+                        </a>
                         {% endif %}
                     {% endif %}
                 </div>


### PR DESCRIPTION
- Enhanced `app_detail.html` to display license URLs with corresponding icons, improving user access to license information

Currently unsure if this ever gets merged or actually add more value to the app-detail-page. Mainly pushed this, so I can see how it actually looks like.