### PR TITLE
chore: prepare aswg for awesome-sysadmin-data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ All notable changes to this project will be documented in this file. The format 
 
 - Fixed link in App detail page, to return to browse page
 - Fixed open-external-new-tab and open-internal-new-tab meta tags to be case-insensitive
+- Made `licenses_nonfree_file` optional so data repos that only ship a free `licenses.yml` (e.g. `awesome-sysadmin-data`) build without errors and the "Include Non-Free" toggle is hidden when no non-free licenses are configured
+- Fixed CLI argument parsing to allow argument to be used after a subcommand
+
+### Other changes
+
+- Templates do now not mention "awesome-selfhosted" hardcoded anymore but instead use the `site_config.title` variable
 
 ## [2.2.0] - 2026-03-08
 

--- a/aswg/cli.py
+++ b/aswg/cli.py
@@ -24,33 +24,35 @@ from .utils import format_bytes, get_directory_size, print_build_stats
 
 def create_parser():
     """Create the argument parser."""
-    parser = argparse.ArgumentParser(
-        description='Awesome Self-Hosted Website Generator - Generate a beautiful static website from the awesome-selfhosted dataset.'
-    )
+    common_parser = argparse.ArgumentParser(add_help=False)
+    common_parser.add_argument('--config', '-c', default='config/config.yml', help='Configuration file path (default: config/config.yml)')
+    common_parser.add_argument('--verbose', '-v', action='store_true', help='Enable verbose output')
 
-    parser.add_argument('--config', '-c', default='config/config.yml', help='Configuration file path (default: config/config.yml)')
-    parser.add_argument('--verbose', '-v', action='store_true', help='Enable verbose output')
+    parser = argparse.ArgumentParser(
+        description='Awesome Self-Hosted Website Generator - Generate a beautiful static website from the awesome-selfhosted dataset.',
+        parents=[common_parser],
+    )
 
     subparsers = parser.add_subparsers(dest='command', help='Available commands')
 
     # Fetch command
-    subparsers.add_parser('fetch', help='Fetch and process awesome-selfhosted data')
+    subparsers.add_parser('fetch', help='Fetch and process awesome-selfhosted data', parents=[common_parser])
 
     # Build command
-    build_parser = subparsers.add_parser('build', help='Build the complete static website')
+    build_parser = subparsers.add_parser('build', help='Build the complete static website', parents=[common_parser])
     build_parser.add_argument('--fetch-first', action='store_true', help='Fetch fresh data before building')
 
     # Watch command
     watch_parser = subparsers.add_parser(
-        'watch', help='Watch for changes and rebuild automatically'
+        'watch', help='Watch for changes and rebuild automatically', parents=[common_parser]
     )
     watch_parser.add_argument('--interval', '-i', type=int, default=5, help='Watch interval in seconds (default: 5)')
 
     # Clean command
-    subparsers.add_parser('clean', help='Clean output and cache directories')
+    subparsers.add_parser('clean', help='Clean output and cache directories', parents=[common_parser])
 
     # Info command
-    subparsers.add_parser('info', help='Show configuration and system information')
+    subparsers.add_parser('info', help='Show configuration and system information', parents=[common_parser])
 
     return parser
 
@@ -288,7 +290,8 @@ def cmd_info(config):  # pylint: disable=too-many-locals,too-many-statements
     print(f"   Categories directory: {data_config.get('categories_dir', 'tags')}")
     print(f"   Platforms directory: {data_config.get('platforms_dir', 'platforms')}")
     print(f"   Licenses file: {data_config.get('licenses_file', 'licenses.yml')}")
-    print(f"   Licenses nonfree file: {data_config.get('licenses_nonfree_file', 'licenses-nonfree.yml')}")
+    nonfree_file = data_config.get('licenses_nonfree_file')
+    print(f"   Licenses nonfree file: {nonfree_file if nonfree_file else '(not configured)'}")
     print(f"   Use git data: {generation_config.get('use_git_data', True)}")
 
     # Cached data

--- a/aswg/data_processor.py
+++ b/aswg/data_processor.py
@@ -84,9 +84,10 @@ class DataProcessor:  # pylint: disable=too-many-instance-attributes
         platforms_dir = data_dir / data_config["platforms_dir"]
         platforms_data = self._load_platforms_data(platforms_dir)
 
-        # Load licenses data (both free and non-free)
+        # Load licenses data (free always, non-free only if configured)
         licenses_file = data_dir / data_config["licenses_file"]
-        licenses_nonfree_file = data_dir / data_config["licenses_nonfree_file"]
+        nonfree_filename = data_config.get("licenses_nonfree_file")
+        licenses_nonfree_file = data_dir / nonfree_filename if nonfree_filename else None
         licenses_data = self._load_licenses_data(licenses_file, licenses_nonfree_file)
 
         # Load markdown files
@@ -199,9 +200,9 @@ class DataProcessor:  # pylint: disable=too-many-instance-attributes
         return platforms_data
 
     def _load_licenses_data(
-        self, licenses_file: Path, licenses_nonfree_file: Path
+        self, licenses_file: Path, licenses_nonfree_file: Optional[Path] = None
     ) -> Dict[str, Dict]:
-        """Load both free and non-free licenses YAML files."""
+        """Load free licenses, plus non-free licenses if a file is provided."""
         licenses_data = {}
 
         # Load free licenses
@@ -224,7 +225,10 @@ class DataProcessor:  # pylint: disable=too-many-instance-attributes
         else:
             print(f"Warning: Licenses file not found: {licenses_file}")
 
-        # Load non-free licenses
+        # Load non-free licenses only if explicitly configured
+        if licenses_nonfree_file is None:
+            return licenses_data
+
         if licenses_nonfree_file.exists():
             try:
                 with open(licenses_nonfree_file, "r", encoding="utf-8") as f:
@@ -242,7 +246,7 @@ class DataProcessor:  # pylint: disable=too-many-instance-attributes
             except (yaml.YAMLError, OSError) as e:
                 print(f"Error loading {licenses_nonfree_file}: {e}")
         else:
-            print(f"Note: Non-free licenses file not found: {licenses_nonfree_file}")
+            print(f"Warning: Non-free licenses file configured but not found: {licenses_nonfree_file}")
 
         return licenses_data
 

--- a/aswg/site_generator.py
+++ b/aswg/site_generator.py
@@ -45,6 +45,12 @@ class SiteGenerator:  # pylint: disable=too-few-public-methods
         # Register template helpers
         self._register_template_functions()
 
+    def _has_nonfree_licenses(self) -> bool:
+        """Return True if any loaded license entry is marked as non-free."""
+        if not self.licenses_data:
+            return False
+        return any(not lic.get("free", True) for lic in self.licenses_data.values())
+
     def _register_template_functions(self):
         """Register custom template functions and filters."""
         # Global functions
@@ -54,6 +60,10 @@ class SiteGenerator:  # pylint: disable=too-few-public-methods
                 "ui_config": self.config.get("ui", {}),
                 "footer_config": self.config.get("footer", {}),
                 "hero_config": self.config.get("hero", {}),
+                "data_config": self.config.get("data", {}),
+                "data_source_name": self.config.get(
+                    "data.display_name", self.config.get("data.data_dir", "data")
+                ),
                 "navigation_config": self.config.get("navigation", {}),
                 "pages_config": self.config.get("pages", {}),
                 "roadmap_config": self.config.get("roadmap", {}),
@@ -63,6 +73,7 @@ class SiteGenerator:  # pylint: disable=too-few-public-methods
                 "generation_config": self.config.get_generation_config(),
                 "search_config": self.config.get_search_config(),
                 "performance_config": self.config.get_performance_config(),
+                "nonfree_supported": self._has_nonfree_licenses(),
                 "format_stars": self.template_helpers.format_stars,
                 "format_date": self.template_helpers.format_date,
                 "format_license": self.template_helpers.format_license,

--- a/aswg/static/js/alternatives.js
+++ b/aswg/static/js/alternatives.js
@@ -69,22 +69,22 @@ class AlternativesPage {
     }
 
     async loadLicenseData() {
-        // Load non-free license identifiers from search data
+        // Load non-free license identifiers from search data.
+        // An empty nonfree_licenses array is the normal state for free-only data repos.
         try {
             const response = await fetch(this.basePath + '/static/data/search.json');
             const data = await response.json();
-            
+
             if (data.nonfree_licenses && Array.isArray(data.nonfree_licenses)) {
                 data.nonfree_licenses.forEach(license => {
                     this.nonFreeLicenses.add(license);
                 });
             } else {
-                // Fallback to basic proprietary check if data not available
+                // Defensive fallback for stale/malformed search.json
                 this.nonFreeLicenses.add('⊘ Proprietary');
             }
         } catch (error) {
             console.error('Failed to load license data:', error);
-            // Fallback to basic proprietary check
             this.nonFreeLicenses.add('⊘ Proprietary');
         }
     }

--- a/aswg/static/js/browse.js
+++ b/aswg/static/js/browse.js
@@ -244,22 +244,23 @@ class BrowsePage {
     }
 
     async loadLicenseData() {
-        // Load non-free license identifiers from search data
+        // Load non-free license identifiers from search data.
+        // An empty nonfree_licenses array is the normal state for free-only data repos;
+        // the toggle DOM is hidden server-side, so no extra signal is required here.
         try {
             const response = await fetch(this.basePath + '/static/data/search.json');
             const data = await response.json();
-            
+
             if (data.nonfree_licenses && Array.isArray(data.nonfree_licenses)) {
                 data.nonfree_licenses.forEach(license => {
                     this.nonFreeLicenses.add(license);
                 });
             } else {
-                // Fallback to basic proprietary check if data not available
+                // Defensive fallback for stale/malformed search.json
                 this.nonFreeLicenses.add('⊘ Proprietary');
             }
         } catch (error) {
             console.error('Failed to load license data:', error);
-            // Fallback to basic proprietary check
             this.nonFreeLicenses.add('⊘ Proprietary');
         }
     }
@@ -936,7 +937,7 @@ class BrowsePage {
     }
 
     setupEventListeners() {
-        // Show non-free toggle
+        // Show non-free toggle (only present in DOM when non-free licenses are configured)
         const showNonFreeToggle = document.getElementById('showNonFree');
         if (showNonFreeToggle) {
             showNonFreeToggle.addEventListener('change', (e) => {

--- a/aswg/templates/base/base.html
+++ b/aswg/templates/base/base.html
@@ -111,7 +111,7 @@
                 <div class="flex items-center">
                     <!-- Logo -->
                     <a href="{{ url_for('/') }}" class="flex items-center space-x-2.5 mr-8">
-                        <img src="{{ asset_url('static/images/logo.svg') }}" alt="Awesome Self-Hosted" class="h-9 w-9">
+                        <img src="{{ asset_url('static/images/logo.svg') }}" alt="{{ site_config.title }} logo" class="h-9 w-9">
                         <span class="text-lg font-bold text-text hidden sm:inline">{{ site_config.title }}</span>
                     </a>
 

--- a/aswg/templates/pages/browse.html
+++ b/aswg/templates/pages/browse.html
@@ -150,6 +150,7 @@
                     <div id="mobileLicenseSearch" class="hidden mb-3">
                         <input type="text" placeholder="Search licenses..." class="w-full px-3 py-2 text-sm bg-surface border border-border rounded focus:outline-none focus:ring-2 focus:ring-primary text-text">
                     </div>
+                    {% if nonfree_supported %}
                     <div class="flex items-center space-x-3 mb-3 pb-3 border-b border-border">
                         <label class="custom-toggle">
                             <input type="checkbox" id="mobileShowNonFree">
@@ -157,6 +158,7 @@
                         </label>
                         <span class="text-sm text-text-muted">Include Non-Free</span>
                     </div>
+                    {% endif %}
                     <div class="space-y-2 max-h-64 overflow-y-auto" id="mobileLicenseFilters">
                         <!-- License checkboxes will be populated by JavaScript -->
                     </div>
@@ -285,6 +287,7 @@
                 <div id="licenseSearch" class="hidden mb-3">
                     <input type="text" placeholder="Search licenses..." class="w-full px-3 py-2 text-sm bg-surface-alt border border-border rounded focus:outline-none focus:ring-2 focus:ring-primary text-text">
                 </div>
+                {% if nonfree_supported %}
                 <div class="flex items-center space-x-3 mb-4 pb-4 border-b border-border">
                     <label class="custom-toggle">
                         <input type="checkbox" id="showNonFree">
@@ -292,6 +295,7 @@
                     </label>
                     <span class="text-sm text-text-muted">Include Non-Free</span>
                 </div>
+                {% endif %}
                 <div class="space-y-2 max-h-64 overflow-y-auto" id="licenseFilters">
                     <!-- License checkboxes will be populated by JavaScript -->
                 </div>

--- a/aswg/templates/pages/index.html
+++ b/aswg/templates/pages/index.html
@@ -25,7 +25,7 @@
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-24">
             <div class="text-center">
                 <h1 class="text-4xl md:text-6xl font-bold text-text mb-6 tracking-tight">
-                    {{ hero_config.get('title', 'Awesome Self-Hosted') }}
+                    {{ hero_config.get('title', site_config.title) }}
                 </h1>
 
                 {% if hero_config.get('subtitle') %}
@@ -365,7 +365,7 @@
                     Statistics
                 </h2>
                 <p class="text-lg text-text-muted">
-                    Deep dive into the awesome-selfhosted ecosystem
+                    Deep dive into the {{ site_config.title }} ecosystem
                 </p>
             </div>
 
@@ -479,7 +479,7 @@
     </div>
 
   {% elif section == 'footer_markdown' and markdown_data.get('footer') %}
-    <!-- Footer Content from awesome-selfhosted-data -->
+    <!-- Footer content from markdown data source -->
     <div class="{{ get_section_bg_class() }} py-16">
         <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
             <div class="text-left">

--- a/config/config-pr-preview.yml
+++ b/config/config-pr-preview.yml
@@ -20,6 +20,8 @@ data:
   categories_dir: "tags"
   platforms_dir: "platforms"
   licenses_file: "licenses.yml"
+  # Optional: omit for data repos that only ship free licenses (e.g. awesome-sysadmin-data).
+  # When unset, the "Include Non-Free" toggle is hidden and no non-free filtering is applied.
   licenses_nonfree_file: "licenses-nonfree.yml"
 
 # =============================================================================

--- a/config/config.yml
+++ b/config/config.yml
@@ -19,6 +19,8 @@ data:
   categories_dir: "tags"
   platforms_dir: "platforms"
   licenses_file: "licenses.yml"
+  # Optional: omit for data repos that only ship free licenses (e.g. awesome-sysadmin-data).
+  # When unset, the "Include Non-Free" toggle is hidden and no non-free filtering is applied.
   licenses_nonfree_file: "licenses-nonfree.yml"
 
 # =============================================================================


### PR DESCRIPTION
This PR resolves any issues that arised from building from a other awesome- list under then awesome-selfhosted (such as awesome-sysadmin). This includes:

- Made `licenses_nonfree_file` optional so data repos that only ship a free `licenses.yml` (e.g. `awesome-sysadmin-data`) build without errors
- Ability to hide the "Include Non-Free" toggle when no non-free licenses are configured
- Ensured no hard-coded references to "awesome-selfhosted" anymore
- Other small fixes and improvements