### PR TITLE
feat: recalculate browse filter facet counts dynamically

### DIFF
--- a/aswg/data_processor.py
+++ b/aswg/data_processor.py
@@ -265,17 +265,10 @@ class DataProcessor:  # pylint: disable=too-many-instance-attributes
             website_url = self._validate_url(app_data.get("website_url")) or ""
             icon_url = self._validate_url(app_data.get("icon_url"))
 
-            # Get platforms (technologies/languages) - keep all platforms
-            platforms = app_data.get("platforms", [])
-            # Ensure platforms is always a list (handle legacy cached data)
-            if isinstance(platforms, str):
-                platforms = [platforms] if platforms else []
-
-            # Get licenses - keep all licenses
-            licenses = app_data.get("licenses", [])
-            # Ensure licenses is always a list (handle legacy cached data)
-            if isinstance(licenses, str):
-                licenses = [licenses] if licenses else []
+            # Normalize string-list facets to avoid whitespace mismatch in frontend filters.
+            platforms = self._normalize_string_list(app_data.get("platforms", []))
+            licenses = self._normalize_string_list(app_data.get("licenses", []))
+            categories = self._normalize_string_list(app_data.get("tags", []))
 
             # Parse description annotations
             desc_data = self._parse_description_annotations(
@@ -296,7 +289,7 @@ class DataProcessor:  # pylint: disable=too-many-instance-attributes
                 repo_url=repo_url,
                 demo_url=demo_url,
                 related_software_url=related_software_url,
-                categories=app_data.get("tags", []),
+                categories=categories,
                 license=licenses,
                 platforms=platforms,
                 stars=app_data.get("stargazers_count"),
@@ -317,6 +310,14 @@ class DataProcessor:  # pylint: disable=too-many-instance-attributes
             applications.append(app)
 
         return applications
+
+    def _normalize_string_list(self, values: Any) -> List[str]:
+        """Normalize list-like facet values by trimming and dropping empty/non-string entries."""
+        if isinstance(values, str):
+            values = [values]
+        if not isinstance(values, list):
+            return []
+        return [value.strip() for value in values if isinstance(value, str) and value.strip()]
 
     def _validate_url(self, url: Optional[Any]) -> Optional[str]:
         """Validate icon_url is a well-formed HTTP/HTTPS URL; return it HTML-escaped for attributes."""

--- a/aswg/static/js/browse.js
+++ b/aswg/static/js/browse.js
@@ -44,6 +44,8 @@ class BrowsePage {
         this.updatedMax = Infinity;
         this.updatedDataMax = 365; // Will be calculated from dataset
         this.includeNoUpdateDate = true; // Include apps without update date by default
+        this.pendingFacetCountTimeout = null;
+        this.facetCountDebounceMs = 80;
 
         this.init();
     }
@@ -533,9 +535,13 @@ class BrowsePage {
             this.updateRangeHighlight(minSlider, maxSlider, highlight);
             this.updateResetButton(resetId, minPos !== 0 || maxPos !== steps.length - 1);
             this.currentPage = 1;
-            this.filterSortAndRender();
+            this.filterSortAndRender({ deferFacetCounts: true });
             // Use this.starsMax to ensure sync matches stored state (may be Infinity when at max)
             this.syncStarsSlider(syncTarget, minVal, this.starsMax);
+        });
+
+        minSlider.addEventListener('change', () => {
+            this.filterSortAndRender();
         });
 
         // Max slider event
@@ -559,8 +565,12 @@ class BrowsePage {
             this.updateRangeHighlight(minSlider, maxSlider, highlight);
             this.updateResetButton(resetId, minPos !== 0 || maxPos !== steps.length - 1);
             this.currentPage = 1;
-            this.filterSortAndRender();
+            this.filterSortAndRender({ deferFacetCounts: true });
             this.syncStarsSlider(syncTarget, minVal, isAtMax ? Infinity : maxVal);
+        });
+
+        maxSlider.addEventListener('change', () => {
+            this.filterSortAndRender();
         });
 
         // Editable min value - allows custom values (not just steps)
@@ -704,9 +714,13 @@ class BrowsePage {
             this.updateRangeHighlight(minSlider, maxSlider, highlight);
             this.updateResetButton(resetId, minPos !== 0 || maxPos !== steps.length - 1);
             this.currentPage = 1;
-            this.filterSortAndRender();
+            this.filterSortAndRender({ deferFacetCounts: true });
             // Use this.updatedMax to ensure sync matches stored state (may be Infinity when at max)
             this.syncUpdatedSlider(syncTarget, minVal, this.updatedMax);
+        });
+
+        minSlider.addEventListener('change', () => {
+            this.filterSortAndRender();
         });
 
         // Max slider event
@@ -729,8 +743,12 @@ class BrowsePage {
             this.updateRangeHighlight(minSlider, maxSlider, highlight);
             this.updateResetButton(resetId, minPos !== 0 || maxPos !== steps.length - 1);
             this.currentPage = 1;
-            this.filterSortAndRender();
+            this.filterSortAndRender({ deferFacetCounts: true });
             this.syncUpdatedSlider(syncTarget, minVal, maxPos === steps.length - 1 ? Infinity : maxVal);
+        });
+
+        maxSlider.addEventListener('change', () => {
+            this.filterSortAndRender();
         });
 
         // Editable min value - allows custom values (not just steps)
@@ -1361,7 +1379,16 @@ class BrowsePage {
         this.updateFilterCountLabels('#mobileCategoryFilters input[data-category]', 'category', categoryCounts);
     }
 
-    filterSortAndRender() {
+    scheduleFacetCountUpdate() {
+        if (this.pendingFacetCountTimeout) return;
+        this.pendingFacetCountTimeout = window.setTimeout(() => {
+            this.pendingFacetCountTimeout = null;
+            this.updateFilterCounts();
+        }, this.facetCountDebounceMs);
+    }
+
+    filterSortAndRender(options = {}) {
+        const { deferFacetCounts = false } = options;
         // Filter applications
         this.filteredApplications = this.applications.filter(app => this.appMatchesFilters(app));
 
@@ -1376,7 +1403,15 @@ class BrowsePage {
         
         // Render current page
         this.renderCurrentPage();
-        this.updateFilterCounts();
+        if (deferFacetCounts) {
+            this.scheduleFacetCountUpdate();
+        } else {
+            if (this.pendingFacetCountTimeout) {
+                clearTimeout(this.pendingFacetCountTimeout);
+                this.pendingFacetCountTimeout = null;
+            }
+            this.updateFilterCounts();
+        }
         this.updateCounts();
         if (this.enablePagination) {
             this.updatePaginationControls();

--- a/aswg/static/js/browse.js
+++ b/aswg/static/js/browse.js
@@ -269,9 +269,7 @@ class BrowsePage {
         this.applications.forEach(app => {
             if (app.platforms) {
                 app.platforms.forEach(platform => {
-                    if (platform && platform.trim()) {
-                        this.platforms.add(platform.trim());
-                    }
+                    if (platform) this.platforms.add(platform);
                 });
             }
         });
@@ -281,9 +279,7 @@ class BrowsePage {
         this.applications.forEach(app => {
             if (app.license) {
                 app.license.forEach(license => {
-                    if (license && license.trim()) {
-                        this.licenses.add(license.trim());
-                    }
+                    if (license) this.licenses.add(license);
                 });
             }
         });
@@ -293,9 +289,7 @@ class BrowsePage {
         this.applications.forEach(app => {
             if (app.categories) {
                 app.categories.forEach(category => {
-                    if (category && category.trim()) {
-                        this.categories.add(category.trim());
-                    }
+                    if (category) this.categories.add(category);
                 });
             }
         });
@@ -1325,9 +1319,8 @@ class BrowsePage {
             const values = app[key];
             if (!Array.isArray(values)) return;
             values.forEach(value => {
-                if (!value || !value.trim()) return;
-                const normalizedValue = value.trim();
-                counts.set(normalizedValue, (counts.get(normalizedValue) || 0) + 1);
+                if (!value) return;
+                counts.set(value, (counts.get(value) || 0) + 1);
             });
         });
         return counts;

--- a/aswg/static/js/browse.js
+++ b/aswg/static/js/browse.js
@@ -1019,7 +1019,7 @@ class BrowsePage {
                        data-platform="${platform}">
                 <span class="flex-1">
                     ${platform}
-                    <span class="text-xs opacity-70 ml-1">(${platformCount})</span>
+                    <span class="filter-count text-xs opacity-70 ml-1">(${platformCount})</span>
                 </span>
             `;
 
@@ -1071,7 +1071,7 @@ class BrowsePage {
                        data-license="${license}">
                 <span class="flex-1">
                     ${license}
-                    <span class="text-xs opacity-70 ml-1">(${licenseCount})</span>
+                    <span class="filter-count text-xs opacity-70 ml-1">(${licenseCount})</span>
                 </span>
             `;
 
@@ -1118,7 +1118,7 @@ class BrowsePage {
                        data-category="${category}">
                 <span class="flex-1">
                     ${category}
-                    <span class="text-xs opacity-70 ml-1">(${categoryCount})</span>
+                    <span class="filter-count text-xs opacity-70 ml-1">(${categoryCount})</span>
                 </span>
             `;
 
@@ -1279,60 +1279,98 @@ class BrowsePage {
         );
     }
 
+    appMatchesFilters(app, excludedFilter = null) {
+        // Platform filter
+        if (excludedFilter !== 'platform' && this.selectedPlatforms.size > 0) {
+            const hasSelectedPlatform = app.platforms &&
+                app.platforms.some(platform => this.selectedPlatforms.has(platform));
+            if (!hasSelectedPlatform) return false;
+        }
+
+        // License filter
+        if (excludedFilter !== 'license' && this.selectedLicenses.size > 0) {
+            const hasSelectedLicense = app.license &&
+                app.license.some(license => this.selectedLicenses.has(license));
+            if (!hasSelectedLicense) return false;
+        }
+
+        // Category filter
+        if (excludedFilter !== 'category' && this.selectedCategories.size > 0) {
+            const hasSelectedCategory = app.categories &&
+                app.categories.some(category => this.selectedCategories.has(category));
+            if (!hasSelectedCategory) return false;
+        }
+
+        // Non-free license filter
+        if (!this.showNonFreeOnly && this.isNonFreeLicense(app.license)) return false;
+
+        // Star count filter
+        const appStars = app.stars || 0;
+        if (appStars < this.starsMin || appStars > this.starsMax) return false;
+
+        // Last updated filter (in days)
+        const daysSinceUpdate = this.getDaysSinceUpdate(app.last_updated);
+        if (daysSinceUpdate !== null) {
+            if (daysSinceUpdate < this.updatedMin || daysSinceUpdate > this.updatedMax) return false;
+        } else if (!this.includeNoUpdateDate) {
+            return false;
+        }
+
+        return true;
+    }
+
+    countFacetValues(apps, key) {
+        const counts = new Map();
+        apps.forEach(app => {
+            const values = app[key];
+            if (!Array.isArray(values)) return;
+            values.forEach(value => {
+                if (!value || !value.trim()) return;
+                const normalizedValue = value.trim();
+                counts.set(normalizedValue, (counts.get(normalizedValue) || 0) + 1);
+            });
+        });
+        return counts;
+    }
+
+    updateFilterCountLabels(selector, dataKey, counts) {
+        document.querySelectorAll(selector).forEach(checkbox => {
+            const value = checkbox.dataset[dataKey];
+            if (!value) return;
+            const label = checkbox.closest('label');
+            if (!label) return;
+            const countNode = label.querySelector('.filter-count');
+            if (!countNode) return;
+            const count = counts.get(value) || 0;
+            countNode.textContent = `(${count})`;
+        });
+    }
+
+    updateFilterCounts() {
+        const platformCounts = this.countFacetValues(
+            this.applications.filter(app => this.appMatchesFilters(app, 'platform')),
+            'platforms'
+        );
+        const licenseCounts = this.countFacetValues(
+            this.applications.filter(app => this.appMatchesFilters(app, 'license')),
+            'license'
+        );
+        const categoryCounts = this.countFacetValues(
+            this.applications.filter(app => this.appMatchesFilters(app, 'category')),
+            'categories'
+        );
+
+        this.updateFilterCountLabels('#platformFilters input[data-platform]', 'platform', platformCounts);
+        this.updateFilterCountLabels('#mobilePlatformFilters input[data-platform]', 'platform', platformCounts);
+        this.updateFilterCountLabels('#licenseFilters input[data-license]', 'license', licenseCounts);
+        this.updateFilterCountLabels('#mobileLicenseFilters input[data-license]', 'license', licenseCounts);
+        this.updateFilterCountLabels('#categoryFilters input[data-category]', 'category', categoryCounts);
+        this.updateFilterCountLabels('#mobileCategoryFilters input[data-category]', 'category', categoryCounts);
+    }
+
     filterSortAndRender() {
         // Filter applications
-        this.filteredApplications = this.applications.filter(app => {
-            // Platform filter
-            if (this.selectedPlatforms.size > 0) {
-                const hasSelectedPlatform = app.platforms && 
-                    app.platforms.some(platform => this.selectedPlatforms.has(platform));
-                if (!hasSelectedPlatform) return false;
-            }
-
-            // License filter
-            if (this.selectedLicenses.size > 0) {
-                const hasSelectedLicense = app.license && 
-                    app.license.some(license => this.selectedLicenses.has(license));
-                if (!hasSelectedLicense) return false;
-            }
-
-            // Category filter
-            if (this.selectedCategories.size > 0) {
-                const hasSelectedCategory = app.categories && 
-                    app.categories.some(category => this.selectedCategories.has(category));
-                if (!hasSelectedCategory) return false;
-            }
-
-            // Non-free license filter
-            if (this.showNonFreeOnly) {
-                // When toggle is ON: show ALL software (free + non-free)
-                // No filtering needed - show everything
-            } else {
-                // When toggle is OFF: hide non-free software (show only free software)
-                if (this.isNonFreeLicense(app.license)) return false;
-            }
-
-            // Star count filter
-            const appStars = app.stars || 0;
-            if (appStars < this.starsMin || appStars > this.starsMax) {
-                return false;
-            }
-
-            // Last updated filter (in days)
-            const daysSinceUpdate = this.getDaysSinceUpdate(app.last_updated);
-            if (daysSinceUpdate !== null) {
-                if (daysSinceUpdate < this.updatedMin || daysSinceUpdate > this.updatedMax) {
-                    return false;
-                }
-            } else {
-                // App has no last_updated date - check if we should include it
-                if (!this.includeNoUpdateDate) {
-                    return false;
-                }
-            }
-
-            return true;
-        });
+        this.filteredApplications = this.applications.filter(app => this.appMatchesFilters(app));
 
         // Sort applications
         this.sortApplications();
@@ -1345,6 +1383,7 @@ class BrowsePage {
         
         // Render current page
         this.renderCurrentPage();
+        this.updateFilterCounts();
         this.updateCounts();
         if (this.enablePagination) {
             this.updatePaginationControls();
@@ -1826,7 +1865,7 @@ class BrowsePage {
                        data-platform="${platform}">
                 <span class="flex-1">
                     ${platform}
-                    <span class="text-xs opacity-70 ml-1">(${platformCount})</span>
+                    <span class="filter-count text-xs opacity-70 ml-1">(${platformCount})</span>
                 </span>
             `;
 
@@ -1881,7 +1920,7 @@ class BrowsePage {
                        data-license="${license}">
                 <span class="flex-1">
                     ${license}
-                    <span class="text-xs opacity-70 ml-1">(${licenseCount})</span>
+                    <span class="filter-count text-xs opacity-70 ml-1">(${licenseCount})</span>
                 </span>
             `;
 
@@ -1927,7 +1966,7 @@ class BrowsePage {
                        data-category="${category}">
                 <span class="flex-1">
                     ${category}
-                    <span class="text-xs opacity-70 ml-1">(${categoryCount})</span>
+                    <span class="filter-count text-xs opacity-70 ml-1">(${categoryCount})</span>
                 </span>
             `;
 


### PR DESCRIPTION
Update browse filter facets to recompute counts from the current active filter state so users see context-aware numbers while narrowing results.