### PR TITLE
perf: reduce redundant generation & client render

### DIFF
--- a/aswg/related_apps.py
+++ b/aswg/related_apps.py
@@ -20,6 +20,7 @@ class RelatedAppsFinder:
         """
         self.config = config
         self.licenses_data = licenses_data
+        self._nonfree_licenses: Optional[Set[str]] = None
         self._cached_app_phrases: Optional[Dict[str, Set[str]]] = None
         self._cached_app_list_id: Optional[int] = None
 
@@ -27,6 +28,19 @@ class RelatedAppsFinder:
         """Clear the cached phrase data. Useful for testing or when app list changes."""
         self._cached_app_phrases = None
         self._cached_app_list_id = None
+
+    def _get_nonfree_licenses(self) -> Set[str]:
+        """Return cached set of non-free license identifiers."""
+        if self._nonfree_licenses is None:
+            if not self.licenses_data:
+                self._nonfree_licenses = set()
+            else:
+                self._nonfree_licenses = {
+                    lic_id
+                    for lic_id, lic_info in self.licenses_data.items()
+                    if not lic_info.get("free", True)
+                }
+        return self._nonfree_licenses
 
     def find_related_apps(
         self,
@@ -534,11 +548,7 @@ class RelatedAppsFinder:
 
         # Get non-free license identifiers from loaded license data
         if self.licenses_data:
-            nonfree_licenses = {
-                lic_id
-                for lic_id, lic_info in self.licenses_data.items()
-                if not lic_info.get("free", True)
-            }
+            nonfree_licenses = self._get_nonfree_licenses()
             return any(lic in nonfree_licenses for lic in app.license)
 
         # Fallback to basic check if license data not available

--- a/aswg/site_generator.py
+++ b/aswg/site_generator.py
@@ -31,6 +31,7 @@ class SiteGenerator:  # pylint: disable=too-few-public-methods
         self.config = config
         self.licenses_data = None
         self.template_helpers = TemplateHelpers(config)
+        self.data_processor = DataProcessor(config)
         self.related_apps_config = self.config.get("related_apps", {})
         self.related_apps_finder = RelatedAppsFinder(self.related_apps_config)
 
@@ -141,18 +142,22 @@ class SiteGenerator:  # pylint: disable=too-few-public-methods
             print("  Search index disabled - skipping search data generation")
 
         # Generate pages
-        self._generate_homepage(applications, categories, statistics, markdown_data)
+        alternatives_data = None
+        if self.config.get("alternatives.enabled", False):
+            alternatives_data = self.data_processor.generate_alternatives_data(applications)
+
+        self._generate_homepage(applications, categories, statistics, markdown_data, alternatives_data)
         self._generate_browse_page(applications, categories)
-        self._generate_statistics_page(applications, categories, statistics)
+        self._generate_statistics_page(statistics)
         self._generate_app_detail_pages(applications)
         if self.config.get("roadmap.enabled", False):
             self._generate_roadmap_page()
 
         # Generate alternatives page
         if self.config.get("alternatives.enabled", False):
-            self._generate_alternatives_page(applications)
+            self._generate_alternatives_page(applications, alternatives_data)
             # Generate alternatives data file for client-side loading
-            self._generate_alternatives_data_file(applications)
+            self._generate_alternatives_data_file(alternatives_data)
             print("Alternatives data file generated")
 
         # Generate additional files
@@ -201,6 +206,7 @@ class SiteGenerator:  # pylint: disable=too-few-public-methods
         categories: Dict,
         statistics: Dict,
         markdown_data: Dict = None,
+        alternatives_data: Dict[str, Any] = None,
     ):
         """Generate the homepage."""
         template = self.jinja_env.get_template("pages/index.html")
@@ -238,10 +244,7 @@ class SiteGenerator:  # pylint: disable=too-few-public-methods
 
         # Get alternatives
         top_alternatives = []
-        if self.config.get("alternatives.enabled", False):
-            processor = DataProcessor(self.config)
-            alternatives_data = processor.generate_alternatives_data(applications)
-
+        if self.config.get("alternatives.enabled", False) and alternatives_data:
             # Get top alternatives (by number of alternative apps)
             min_alternatives = self.config.get("alternatives.min_alternatives", 2)
 
@@ -373,10 +376,10 @@ class SiteGenerator:  # pylint: disable=too-few-public-methods
             f"  Browse page generated (client-side rendering for {len(applications)} apps)"
         )
 
-    def _generate_alternatives_page(self, applications: List[Application]):
+    def _generate_alternatives_page(self, applications: List[Application], alternatives_data: Dict[str, Any] = None):
         """Generate the alternatives page."""
-        processor = DataProcessor(self.config)
-        alternatives_data = processor.generate_alternatives_data(applications)
+        if alternatives_data is None:
+            alternatives_data = self.data_processor.generate_alternatives_data(applications)
 
         # Apply minimum alternatives filter
         min_alternatives = self.config.get("alternatives.min_alternatives", 2)
@@ -385,18 +388,12 @@ class SiteGenerator:  # pylint: disable=too-few-public-methods
             if len(apps) >= min_alternatives
         }
 
-        # Convert Application objects to dictionaries for JSON serialization
-        filtered_alternatives = {}
-        for name, apps in filtered_alternatives_raw.items():
-            filtered_alternatives[name] = [asdict(app) for app in apps]
-
         template = self.jinja_env.get_template("pages/alternatives.html")
 
         content = template.render(
-            alternatives=filtered_alternatives,
             alternatives_statistics=alternatives_data['statistics'],
-            total_software=len(filtered_alternatives),
-            total_alternatives=sum(len(apps) for apps in filtered_alternatives.values()),
+            total_software=len(filtered_alternatives_raw),
+            total_alternatives=sum(len(apps) for apps in filtered_alternatives_raw.values()),
             total_all_applications=len(applications),  # Total applications in the dataset
             alternatives_config=self.config.get("alternatives", {}),
             page_title="Alternative Software"
@@ -409,16 +406,13 @@ class SiteGenerator:  # pylint: disable=too-few-public-methods
         with open(output_path, "w", encoding="utf-8") as f:
             f.write(content)
 
-        print(f"Alternatives page generated ({len(filtered_alternatives)} software with alternatives)")
+        print(f"Alternatives page generated ({len(filtered_alternatives_raw)} software with alternatives)")
 
-    def _generate_statistics_page(
-        self, applications: List[Application], categories: Dict, statistics: Dict):
+    def _generate_statistics_page(self, statistics: Dict):
         """Generate the statistics page."""
         template = self.jinja_env.get_template("pages/statistics.html")
 
         content = template.render(
-            applications=applications,
-            categories=categories,
             statistics=statistics,
             page_title="Statistics",
         )
@@ -535,11 +529,8 @@ class SiteGenerator:  # pylint: disable=too-few-public-methods
 
         print("  Search data file generated")
 
-    def _generate_alternatives_data_file(self, applications: List[Application]) -> Dict[str, Any]:
+    def _generate_alternatives_data_file(self, alternatives_data: Dict[str, Any]) -> Dict[str, Any]:
         """Generate alternatives data JSON file for client-side alternatives page."""
-        processor = DataProcessor(self.config)
-        alternatives_data = processor.generate_alternatives_data(applications)
-
         # Apply minimum alternatives filter
         min_alternatives = self.config.get("alternatives.min_alternatives", 2)
         filtered_alternatives = {
@@ -566,45 +557,44 @@ class SiteGenerator:  # pylint: disable=too-few-public-methods
 
         return json_data
 
+    def _write_sitemap_url(
+        self, file_handle, site_url: str, path: str, current_date: str, priority: str
+    ):
+        """Write one sitemap URL entry to file."""
+        file_handle.write(
+            "  <url>\n"
+            f"    <loc>{site_url}{path}</loc>\n"
+            f"    <lastmod>{current_date}</lastmod>\n"
+            "    <changefreq>weekly</changefreq>\n"
+            f"    <priority>{priority}</priority>\n"
+            "  </url>\n"
+        )
+
     def _generate_sitemap(self, applications: List[Application]):
         """Generate XML sitemap."""
-
-        template = self.jinja_env.get_template("sitemap.xml")
-        base_path = self.config.get('site.base_path', '').rstrip('/')
-
-        # Current date in W3C Datetime format (YYYY-MM-DD)
-        current_date = datetime.now().strftime('%Y-%m-%d')
-
-        urls = [
-            {"loc": base_path + "/", "lastmod": current_date, "priority": "1.0"},  # Homepage
-            {"loc": base_path + "/browse.html", "lastmod": current_date, "priority": "0.9"},  # Browse page
-            {"loc": base_path + "/statistics.html", "lastmod": current_date, "priority": "0.7"},  # Statistics page
+        base_path = self.config.get("site.base_path", "").rstrip("/")
+        site_url = self.config.get("site.url", "https://awesome-selfhosted.net") + base_path
+        current_date = datetime.now().strftime("%Y-%m-%d")
+        static_paths = [
+            ("/", "1.0"),
+            ("/browse.html", "0.9"),
+            ("/statistics.html", "0.7"),
         ]
-
         if self.config.get("roadmap.enabled", False):
             # Roadmap is a first-class interactive workflow, so keep priority aligned with alternatives.
-            urls.append({"loc": base_path + "/roadmap.html", "lastmod": current_date, "priority": "0.8"})
-
-        # Add alternatives page if enabled
+            static_paths.append(("/roadmap.html", "0.8"))
         if self.config.get("alternatives.enabled", False):
-            urls.append({"loc": base_path + "/alternatives.html", "lastmod": current_date, "priority": "0.8"})
-
-        # Add application pages
-        for app in applications:
-            urls.append({
-                "loc": base_path + f"/apps/{app.id}.html",
-                "lastmod": current_date,
-                "priority": "0.1"
-            })
-
-        content = template.render(
-            urls=urls,
-            site_url=self.config.get("site.url", "https://awesome-selfhosted.net") + base_path,
-        )
+            static_paths.append(("/alternatives.html", "0.8"))
 
         output_path = self.config.output_dir / "sitemap.xml"
         with open(output_path, "w", encoding="utf-8") as f:
-            f.write(content)
+            f.write('<?xml version="1.0" encoding="UTF-8"?>\n')
+            f.write('<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n')
+            for path, priority in static_paths:
+                self._write_sitemap_url(f, site_url, path, current_date, priority)
+            for app in applications:
+                self._write_sitemap_url(f, site_url, f"/apps/{app.id}.html", current_date, "0.1")
+            f.write("</urlset>\n")
 
         print("  Sitemap generated")
 

--- a/aswg/static/js/alternatives.js
+++ b/aswg/static/js/alternatives.js
@@ -30,6 +30,9 @@ class AlternativesPage {
         this.itemsPerPage = 60;
         this.totalPages = 1;
         this.enablePagination = true;
+        this.searchRenderDebounceMs = 180;
+        this.pendingSearchTimeout = null;
+        this.searchData = null;
         
         this.init();
     }
@@ -72,11 +75,19 @@ class AlternativesPage {
         // Load non-free license identifiers from search data.
         // An empty nonfree_licenses array is the normal state for free-only data repos.
         try {
-            const response = await fetch(this.basePath + '/static/data/search.json');
-            const data = await response.json();
+            if (!window.__aswgSearchDataPromise) {
+                window.__aswgSearchDataPromise = fetch(this.basePath + '/static/data/search.json')
+                    .then(response => response.json())
+                    .catch(error => {
+                        console.error('Failed to load shared search data:', error);
+                        return {};
+                    });
+            }
+            const data = await window.__aswgSearchDataPromise;
+            this.searchData = data || {};
 
-            if (data.nonfree_licenses && Array.isArray(data.nonfree_licenses)) {
-                data.nonfree_licenses.forEach(license => {
+            if (this.searchData.nonfree_licenses && Array.isArray(this.searchData.nonfree_licenses)) {
+                this.searchData.nonfree_licenses.forEach(license => {
                     this.nonFreeLicenses.add(license);
                 });
             } else {
@@ -205,6 +216,13 @@ class AlternativesPage {
     }
 
     handleSearchInput(query) {
+        if (this.pendingSearchTimeout) clearTimeout(this.pendingSearchTimeout);
+        this.pendingSearchTimeout = setTimeout(() => {
+            this.applySearchInput(query);
+        }, this.searchRenderDebounceMs);
+    }
+
+    applySearchInput(query) {
         if (query.length === 0) {
             // Show all alternatives when search is empty
             this.filteredAlternatives = { ...this.alternatives };
@@ -298,6 +316,7 @@ class AlternativesPage {
     }
 
     selectSuggestion(suggestion) {
+        if (this.pendingSearchTimeout) clearTimeout(this.pendingSearchTimeout);
         const heroSearch = document.getElementById('alternatives-search');
         if (!heroSearch) {
             console.warn('Search input element not found');
@@ -306,9 +325,7 @@ class AlternativesPage {
         
         heroSearch.value = suggestion;
         this.hideSearchSuggestions();
-        this.filterAlternatives(suggestion);
-        this.currentPage = 1; // Reset to first page
-        this.renderAlternatives();
+        this.applySearchInput(suggestion);
     }
 
     handleKeyboardNavigation(e) {
@@ -434,11 +451,13 @@ class AlternativesPage {
         }
 
         // Render each software group
+        const fragment = document.createDocumentFragment();
         pageSoftwareNames.forEach(softwareName => {
             const alternatives = this.filteredAlternatives[softwareName];
             const groupElement = this.createSoftwareGroup(softwareName, alternatives);
-            container.appendChild(groupElement);
+            fragment.appendChild(groupElement);
         });
+        container.appendChild(fragment);
 
         // Update statistics to reflect current filtered state
         this.updateStatistics();
@@ -499,11 +518,12 @@ class AlternativesPage {
         
         // Show only first N alternatives initially, or all if N or fewer
         const alternativesToShow = alternatives.slice(0, this.alternativesShowMoreThreshold);
-        
+        const initialCardsFragment = document.createDocumentFragment();
         alternativesToShow.forEach(app => {
             const appCard = this.createApplicationCard(app);
-            gridDiv.appendChild(appCard);
+            initialCardsFragment.appendChild(appCard);
         });
+        gridDiv.appendChild(initialCardsFragment);
         
         // Add "Show More" button if there are more than threshold alternatives
         if (alternatives.length > this.alternativesShowMoreThreshold) {
@@ -518,10 +538,12 @@ class AlternativesPage {
             showMoreButton.addEventListener('click', () => {
                 // Add remaining alternatives
                 const remainingAlternatives = alternatives.slice(this.alternativesShowMoreThreshold);
+                const remainingCardsFragment = document.createDocumentFragment();
                 remainingAlternatives.forEach(app => {
                     const appCard = this.createApplicationCard(app);
-                    gridDiv.appendChild(appCard);
+                    remainingCardsFragment.appendChild(appCard);
                 });
+                gridDiv.appendChild(remainingCardsFragment);
                 
                 // Remove show more button
                 showMoreDiv.remove();

--- a/aswg/static/js/browse.js
+++ b/aswg/static/js/browse.js
@@ -10,6 +10,7 @@ class BrowsePage {
         this.categories = new Set();
         this.selectedCategories = new Set();
         this.nonFreeLicenses = new Set();
+        this.searchData = null;
         this.showNonFreeOnly = false;
         this.currentSort = 'name';
         this.basePath = document.querySelector('meta[name="base-path"]')?.content || '';
@@ -118,11 +119,19 @@ class BrowsePage {
 
     async loadSearchData() {
         try {
-            const response = await fetch(this.basePath + '/static/data/search.json');
-            const data = await response.json();
-            this.applications = data.apps || [];
+            if (!window.__aswgSearchDataPromise) {
+                window.__aswgSearchDataPromise = fetch(this.basePath + '/static/data/search.json')
+                    .then(response => response.json())
+                    .catch(error => {
+                        console.error('Failed to load shared search data:', error);
+                        return {};
+                    });
+            }
+            const data = await window.__aswgSearchDataPromise;
+            this.searchData = data || {};
+            this.applications = this.searchData.apps || [];
             this.filteredApplications = [...this.applications];
-            this.gitDataAvailable = data.git_data_available || false;
+            this.gitDataAvailable = this.searchData.git_data_available || false;
         } catch (error) {
             console.error('Failed to load search data:', error);
         }
@@ -250,8 +259,10 @@ class BrowsePage {
         // An empty nonfree_licenses array is the normal state for free-only data repos;
         // the toggle DOM is hidden server-side, so no extra signal is required here.
         try {
-            const response = await fetch(this.basePath + '/static/data/search.json');
-            const data = await response.json();
+            if (!this.searchData) {
+                await this.loadSearchData();
+            }
+            const data = this.searchData || {};
 
             if (data.nonfree_licenses && Array.isArray(data.nonfree_licenses)) {
                 data.nonfree_licenses.forEach(license => {
@@ -535,7 +546,6 @@ class BrowsePage {
             this.updateRangeHighlight(minSlider, maxSlider, highlight);
             this.updateResetButton(resetId, minPos !== 0 || maxPos !== steps.length - 1);
             this.currentPage = 1;
-            this.filterSortAndRender({ deferFacetCounts: true });
             // Use this.starsMax to ensure sync matches stored state (may be Infinity when at max)
             this.syncStarsSlider(syncTarget, minVal, this.starsMax);
         });
@@ -565,7 +575,6 @@ class BrowsePage {
             this.updateRangeHighlight(minSlider, maxSlider, highlight);
             this.updateResetButton(resetId, minPos !== 0 || maxPos !== steps.length - 1);
             this.currentPage = 1;
-            this.filterSortAndRender({ deferFacetCounts: true });
             this.syncStarsSlider(syncTarget, minVal, isAtMax ? Infinity : maxVal);
         });
 
@@ -714,7 +723,6 @@ class BrowsePage {
             this.updateRangeHighlight(minSlider, maxSlider, highlight);
             this.updateResetButton(resetId, minPos !== 0 || maxPos !== steps.length - 1);
             this.currentPage = 1;
-            this.filterSortAndRender({ deferFacetCounts: true });
             // Use this.updatedMax to ensure sync matches stored state (may be Infinity when at max)
             this.syncUpdatedSlider(syncTarget, minVal, this.updatedMax);
         });
@@ -743,7 +751,6 @@ class BrowsePage {
             this.updateRangeHighlight(minSlider, maxSlider, highlight);
             this.updateResetButton(resetId, minPos !== 0 || maxPos !== steps.length - 1);
             this.currentPage = 1;
-            this.filterSortAndRender({ deferFacetCounts: true });
             this.syncUpdatedSlider(syncTarget, minVal, maxPos === steps.length - 1 ? Infinity : maxVal);
         });
 
@@ -1496,10 +1503,12 @@ class BrowsePage {
         }
 
         // Render applications for current page
+        const fragment = document.createDocumentFragment();
         pageApplications.forEach(app => {
             const appCard = this.createApplicationCard(app);
-            gridContainer.appendChild(appCard);
+            fragment.appendChild(appCard);
         });
+        gridContainer.appendChild(fragment);
 
         // Show loading message if no applications
         if (pageApplications.length === 0) {

--- a/aswg/static/js/search.js
+++ b/aswg/static/js/search.js
@@ -8,8 +8,10 @@
     // Initialize search when page loads
     document.addEventListener('DOMContentLoaded', function() {
         loadSearchConfig();
-        loadSearchData();
         initializeSearchInputs();
+        if (hasSearchResultInputs()) {
+            loadSearchData();
+        }
     });
     
     // Load search configuration from meta tags
@@ -25,14 +27,23 @@
         };
     }
     const basePath = document.querySelector('meta[name="base-path"]')?.content || '';
+
+    function hasSearchResultInputs() {
+        return Boolean(document.getElementById('search-input') || document.getElementById('mobile-search-input'));
+    }
     
     // Load search data
     async function loadSearchData() {
         try {
-            const response = await fetch(basePath + '/static/data/search.json');
-            if (response.ok) {
-                searchData = await response.json();
+            if (!window.__aswgSearchDataPromise) {
+                window.__aswgSearchDataPromise = fetch(basePath + '/static/data/search.json')
+                    .then(response => response.ok ? response.json() : {})
+                    .catch(error => {
+                        console.warn('Search data not available:', error);
+                        return {};
+                    });
             }
+            searchData = await window.__aswgSearchDataPromise;
         } catch (error) {
             console.warn('Search data not available:', error);
         }


### PR DESCRIPTION
Reuse alternatives/license data across generation steps, streamline sitemap writing, and cut duplicate search-data fetches/re-renders in browse/alternatives pages to lower CPU/IO work without changing behavior

ToDo:

- Optimize related-app computation complexity:
  - Introduce candidate pre-indexing (category/platform/license buckets) before scoring.
  - Add memoization for repeated pairwise similarity scoring where possible.
